### PR TITLE
Adds User-Agent header in the request

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -30,6 +30,7 @@ function Strategy(options, verify) {
     }
     this._key = options.stackAppsKey;
     this._oauth2.setAccessTokenName('access_token');
+    this._userAgentHeader = options.userAgentHeader || 'request';
 }
 
 
@@ -66,6 +67,9 @@ Strategy.prototype.userProfile = function(accessToken, done) {
         url: this._profileURL,
         // @see https://api.stackexchange.com/docs/compression
         gzip: true,
+        headers: {
+            'User-Agent': this._userAgentHeader,
+        },
         qs: {
             /* jshint ignore:start */
             // key must be passed on every request


### PR DESCRIPTION
Cloudflare which is Stack Exchanges firewall started blocking requests without the User-Agent header

https://meta.stackexchange.com/questions/402158/cloudflare-blocking-api-stackexchange-2-2-search-requests-from-cloud-service-sin